### PR TITLE
Add basic test suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jdpolicano/govault
 
-go 1.24.5
+go 1.24

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jdpolicano/govault/internal/server"
+)
+
+func TestValidateAuthRequest(t *testing.T) {
+	body := bytes.NewBufferString(`{"username":"u","password":"p"}`)
+	req := httptest.NewRequest("POST", "/", body)
+	cred, err := server.ValidateAuthRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.Username != "u" || cred.Password != "p" {
+		t.Errorf("unexpected credentials: %+v", cred)
+	}
+}

--- a/tests/json_store_test.go
+++ b/tests/json_store_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdpolicano/govault/internal/store"
+)
+
+func TestJSONStoreUserLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	js := store.NewJSONStore(dir)
+
+	if js.HasUser("bob") {
+		t.Fatalf("expected store to have no users")
+	}
+
+	err := js.AddUser("bob", []byte("login"), []byte("salt"))
+	if err != nil {
+		t.Fatalf("AddUser returned error: %v", err)
+	}
+
+	if !js.HasUser("bob") {
+		t.Errorf("expected HasUser to return true")
+	}
+
+	u, ok := js.GetUserInfo("bob")
+	if !ok || u.Name != "bob" {
+		t.Fatalf("GetUserInfo returned wrong user")
+	}
+
+	// check file exists
+	path := filepath.Join(dir, "bob", "secrets.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected user file to exist: %v", err)
+	}
+
+	// test Set and Get
+	err = js.Set("bob", "key", store.CipherText{Nonce: []byte("n"), Text: []byte("c")})
+	if err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+	ct, ok := js.Get("bob", "key")
+	if !ok || !ct.Equal(store.CipherText{Nonce: []byte("n"), Text: []byte("c")}) {
+		t.Fatalf("Get returned wrong value")
+	}
+}

--- a/tests/response_test.go
+++ b/tests/response_test.go
@@ -1,0 +1,25 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jdpolicano/govault/internal/server"
+)
+
+func TestJSONResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	server.JSONResponse(rec, server.NewResponse(200, "ok", nil))
+
+	if rec.Code != 200 {
+		t.Fatalf("expected status 200 got %d", rec.Code)
+	}
+	var res server.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &res); err != nil {
+		t.Fatalf("invalid json response: %v", err)
+	}
+	if res.Data != "ok" || res.Error != "" || res.Code != 200 {
+		t.Errorf("unexpected response %+v", res)
+	}
+}

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jdpolicano/govault/internal/server"
+)
+
+func TestSessionExpiration(t *testing.T) {
+	sess := server.NewSession("me", []byte("key"), time.Second)
+	if sess.Expired() {
+		t.Fatalf("session should not be expired immediately")
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if !sess.Expired() {
+		t.Fatalf("session should be expired after ttl")
+	}
+}
+
+func TestSessionMapOperations(t *testing.T) {
+	sm := server.NewSessionMap()
+	sm.Set("a", server.NewSession("u", []byte("k"), time.Minute))
+	if _, ok := sm.Get("a"); !ok {
+		t.Fatalf("expected to retrieve session")
+	}
+	sm.Delete("a")
+	if _, ok := sm.Get("a"); ok {
+		t.Fatalf("expected session to be deleted")
+	}
+}
+
+func TestGenerateSessionID(t *testing.T) {
+	id1, err := server.GenerateSessionID()
+	if err != nil {
+		t.Fatalf("error generating session id: %v", err)
+	}
+	id2, err := server.GenerateSessionID()
+	if err != nil {
+		t.Fatalf("error generating session id: %v", err)
+	}
+	if id1 == id2 {
+		t.Errorf("expected unique session ids")
+	}
+	if len(id1) == 0 || len(id2) == 0 {
+		t.Errorf("ids should not be empty")
+	}
+}

--- a/tests/vault_test.go
+++ b/tests/vault_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"github.com/jdpolicano/govault/internal/vault"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	key, err := vault.NewKey("password", 16)
+	if err != nil {
+		t.Fatalf("failed to create key: %v", err)
+	}
+	cipher, nonce, err := key.Encrypt("secret")
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+	plain, err := key.Decrypt(nonce, string(cipher))
+	if err != nil {
+		t.Fatalf("decrypt failed: %v", err)
+	}
+	if string(plain) != "secret" {
+		t.Errorf("expected decrypted text to match, got %q", plain)
+	}
+}
+
+func TestGenerateRandBytes(t *testing.T) {
+	b, err := vault.GenerateRandBytes(32)
+	if err != nil {
+		t.Fatalf("GenerateRandBytes returned error: %v", err)
+	}
+	if len(b) != 32 {
+		t.Errorf("expected 32 bytes, got %d", len(b))
+	}
+}
+
+func TestDeriveKeyWithSaltConsistency(t *testing.T) {
+	salt, err := vault.GenerateRandBytes(16)
+	if err != nil {
+		t.Fatalf("failed to generate salt: %v", err)
+	}
+	k1, err := vault.NewKeyWithSalt("pass", salt)
+	if err != nil {
+		t.Fatalf("NewKeyWithSalt error: %v", err)
+	}
+	k2, err := vault.NewKeyWithSalt("pass", salt)
+	if err != nil {
+		t.Fatalf("NewKeyWithSalt error: %v", err)
+	}
+	if string(k1.Login) != string(k2.Login) || string(k1.AES) != string(k2.AES) {
+		t.Errorf("keys derived with same salt differ")
+	}
+}


### PR DESCRIPTION
## Summary
- add basic tests for store, vault, server utilities, and sessions
- add a dedicated `tests` directory
- set go version to 1.24 in go.mod for compatibility

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b8876e130832ea1a63c5f2d79abe4